### PR TITLE
Fixed bug with HTTPS detection

### DIFF
--- a/widget-context.php
+++ b/widget-context.php
@@ -135,7 +135,7 @@ class widget_context {
 		else 
 			$uri = $_SERVER['REQUEST_URI'];
 		
-		return (!empty($_SERVER['HTTPS'])) 
+		return (!(empty($_SERVER['HTTPS']) || $_SERVER['HTTPS'] == 'off')) 
 			? "https://".$_SERVER['SERVER_NAME'].$uri 
 			: "http://".$_SERVER['SERVER_NAME'].$uri;
 	}


### PR DESCRIPTION
According to the PHP docs (http://php.net/manual/en/reserved.variables.server.php), the $_SERVER['HTTPS'] value should be empty if HTTPS is not used, but is set to the value "off" on some IIS configurations. I discovered that my web host (Webfaction) seemed to be using "off" as a value as well, for reasons unknown (they are most definitely not running IIS). This mis-detection caused all URL-dependant widgets to disappear. This change checks for either empty or the "off" value.
