### PR TITLE
Use real URIs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,9 @@ Widget Context allows you to show or hide widgets on certain sections of your si
 
 ## Changelog
 
+### 1.0.5 (September 14, 2016)
+* Fix URL targeting of custom permalinks and query strings.
+
 ### 1.0.4 (May 6, 2016)
 * Confirm the plugin works with the latest version of WordPress.
 * Fix the PHP class constructor warning.

--- a/widget-context.php
+++ b/widget-context.php
@@ -418,8 +418,6 @@ class widget_context {
 
 	function match_path( $patterns ) {
 
-		global $wp;
-
 		$patterns_safe = array();
 
 		// Get the request URI

--- a/widget-context.php
+++ b/widget-context.php
@@ -422,12 +422,8 @@ class widget_context {
 
 		$patterns_safe = array();
 
-		// Get the request URI from WP
-		$url_request = $wp->request;
-
-		// Append the query string
-		if ( ! empty( $_SERVER['QUERY_STRING'] ) )
-			$url_request .= '?' . $_SERVER['QUERY_STRING'];
+		// Get the request URI
+		$url_request = trim( $_SERVER['REQUEST_URI'], '/' );
 
 		$rows = explode( "\n", $patterns );
 

--- a/widget-context.php
+++ b/widget-context.php
@@ -3,7 +3,7 @@
 Plugin Name: Widget Context
 Plugin URI: https://wordpress.org/plugins/widget-context/
 Description: Show or hide widgets depending on the section of the site that is being viewed.
-Version: 1.0.4
+Version: 1.0.5
 Author: Kaspars Dambis
 Author URI: https://kaspars.net
 Text Domain: widget-context
@@ -14,7 +14,7 @@ widget_context::instance();
 
 class widget_context {
 
-	private $asset_version = '1.0.4';
+	private $asset_version = '1.0.5';
 	private $sidebars_widgets;
 	private $options_name = 'widget_logic_options'; // Context settings for widgets (visibility, etc)
 	private $settings_name = 'widget_context_settings'; // Widget Context global settings


### PR DESCRIPTION
WordPress permalink settings enable users to rewrite the url structure. As a result, your original `$wp->request . '?' . $_SERVER['QUERY_STRING']` may not always be accurate. In the case of the "Default" link structure, it works fine. However "Post Name" link structure adds a slash after the name and before any url parameters. This caused issue #14. This update fixes the problem.
