### PR TITLE
Update class-widget-context.php

### DIFF
--- a/class/class-widget-context.php
+++ b/class/class-widget-context.php
@@ -214,14 +214,14 @@ class widget_context {
 
 		wp_enqueue_style(
 			'widget-context-css',
-			plugins_url( 'css/admin.css', plugin_basename( __FILE__ ) ),
+			plugins_url( '../css/admin.css', plugin_basename( __FILE__ ) ),
 			null,
 			$this->asset_version
 		);
 
 		wp_enqueue_script(
 			'widget-context-js',
-			plugins_url( 'js/widget-context.js', plugin_basename( __FILE__ ) ),
+			plugins_url( '../js/widget-context.js', plugin_basename( __FILE__ ) ),
 			array( 'jquery' ),
 			$this->asset_version
 		);


### PR DESCRIPTION
The following errors are occurring in the latest release of the plugin:

`GET http://j3.test/wp-content/plugins/widget-context/class/css/admin.css?ver=1.0.4 net::ERR_ABORTED`

`GET http://j3.test/wp-content/plugins/widget-context/class/js/widget-context.js?ver=1.0.4 net::ERR_ABORTED`

The plugin is looking for `admin.css `and `widget-context.js` in the class folder instead of one directory up.

The proposed changes fix the incorrect directory paths.