### PR TITLE
Fix path matcher for URIs with query params

### DIFF
--- a/readme.txt.md
+++ b/readme.txt.md
@@ -67,7 +67,7 @@ Specify URLs to ignore even if they're matched by any of the other context rules
 
 ### 1.3.0 (April 23, 2020)
 
-- Introduce the long-awaited "Exclude by URL" feature to prevent certain URLs from showing or hiding a widget when it's matched by any other visbility rule.
+- Introduce the long-awaited "Exclude by URL" feature to prevent certain URLs from showing or hiding a widget when it's matched by any other visibility rule.
 - Introduce [premium support](https://widgetcontext.com/pro) to help maintain the plugin. Subscribe now to get the PRO version of the Widget Context for free when it's launched!
 
 ### 1.2.0 (August 20, 2019)

--- a/src/UriRules.php
+++ b/src/UriRules.php
@@ -39,7 +39,8 @@ class UriRules {
 	 */
 	public function has_rules_with_query_strings() {
 		foreach ( $this->rules as $rule ) {
-			if ( false !== strpos( $rule, '?' ) ) {
+			// Assume that only query parameters can contain equal signs.
+			if ( false !== strpos( $rule, '=' ) ) {
 				return true;
 			}
 		}

--- a/tests/php/WidgetContextTargetByUrlTest.php
+++ b/tests/php/WidgetContextTargetByUrlTest.php
@@ -116,7 +116,20 @@ class WidgetContextTargetByUrlTest extends WidgetContextTestCase {
 		);
 	}
 
+	public function testQueryStringsWithWildcards() {
+		$this->assertTrue(
+			$this->plugin->match_path( 'categoria-producte/cosmetica/?pwb-brand-filter=clarins', '*pwb-brand-filter=*' ),
+			'Matching query param key with wrapping wildcards'
+		);
+
+		$this->assertTrue(
+			$this->plugin->match_path( 'producte/cosmetica?pwb-brand-filter=clarins', '*/cosmetica/?pwb-brand-filter=*' ),
+			'Ignore trailing slashes on rule paths'
+		);
+	}
+
 	public function testUrlSpecial() {
+		// Disregard things like utm_source and other tracking parameters.
 		$this->assertTrue(
 			$this->plugin->match_path( 'campaigns?cc=automotive', 'campaigns/' ),
 			'Ignore query string because no rules use it'

--- a/tests/php/WidgetContextTest.php
+++ b/tests/php/WidgetContextTest.php
@@ -50,6 +50,12 @@ class WidgetContextTest extends WidgetContextTestCase {
 			'path-to-a/url.html',
 			$this->plugin->path_from_uri( 'path-to-a/url.html' )
 		);
+
+		$this->assertEquals(
+			'producte/cosmetica?pwb-brand-filter=clarins',
+			$this->plugin->path_from_uri( 'producte/cosmetica/?pwb-brand-filter=clarins' ),
+			'Normalize the path by removing the trailing slash'
+		);
 	}
 
 }


### PR DESCRIPTION
- Use `=` sign instead of `?` for detecting the presence of query parameters in paths.
- Add unit tests to confirm that.